### PR TITLE
Remove using namespace std which is not a great code practice

### DIFF
--- a/src/ChargeTimeExtraction.c
+++ b/src/ChargeTimeExtraction.c
@@ -19,10 +19,9 @@
 
 #include "ChargeTimeExtraction.h"
 
-using namespace std; 
 
 void ChargeTimeExtraction(){
-  cout<<"fine"<<endl;
+  std::cout<<"fine"<<std::endl;
 
 }
 
@@ -62,20 +61,20 @@ int InitChargeCalibration(const char *file_name,float *single_pe){
 
   int flag=0;
 
-  ifstream ff(file_name);
+  std::ifstream ff(file_name);
   if(!ff.is_open()) {
-      cout << "Error opening calibration file " << file_name << "\n" << endl;
+      std::cout << "Error opening calibration file " << file_name << "\n" << std::endl;
       return 0; 
   }
 
   float dummy;
-  string line;
+  std::string line;
   int iCh;
   //float single_pe;
   std::getline(ff, line);
   fprintf(stderr,"Gain per channel taken from the calibration file %s \n", file_name); 
   fprintf(stderr,"%s\n",line.c_str());
-  //cout<<line<<endl;
+  //std::cout<<line<<std::endl;
   while (std::getline(ff, line))
       {
 	std::istringstream iss(line);

--- a/src_exe/Flash2Falcon.c
+++ b/src_exe/Flash2Falcon.c
@@ -13,7 +13,6 @@
 //DAQ
 #include "ChargeTimeExtraction.h" 
 
-using namespace std;
 
 //global parameters from the command line
 int debug = 0;

--- a/src_exe/single_pe.c
+++ b/src_exe/single_pe.c
@@ -22,7 +22,6 @@
 #include "ChargeTimeExtraction.h"
 
 # define nChFADC 24
-using namespace std;
 
 int 	debug=0; 
 int 	us=4; 
@@ -171,7 +170,7 @@ int main(int argc, char**argv)
      TF1 *f1 = new TF1("f1","[0]*TMath::Power(([1]/[2]),(x/[2]))*(TMath::Exp(-([1]/[2])))/TMath::Gamma((x/[2])+1)"); // "xmin" = 0, "xmax" = 10
 
      TCanvas *c = new TCanvas("c","",600,400);
-     outfile<<"Channel \t Single PE \t Calibration flag"<<endl;
+     outfile<<"Channel \t Single PE \t Calibration flag"<<std::endl;
      for (int iCh=0;iCh<adcs;iCh++) 
        {
 	 if (flag==1){
@@ -215,7 +214,7 @@ int main(int argc, char**argv)
 	   hdiff[iCh]->Write();
 	 }
 	 
-	 outfile<<iCh<<"\t\t"<<Single_PE<<"\t\t"<<flag<<endl;
+	 outfile<<iCh<<"\t\t"<<Single_PE<<"\t\t"<<flag<<std::endl;
        }
      outfile.close();
      f->Close(); 


### PR DESCRIPTION
This is not a great thing because it can create collision and it makes things more readable (my own opinion)